### PR TITLE
静的ページ出力の設定にして GitHub Pages 用にデプロイできる Workflows を追加

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,12 +8,14 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
 
-     - name:  Set repository name
+    - name:  Set repository name
       id: extract_repo
       run: |
         REPO_NAME=$(echo ${{ github.repository }} | sed -e "s#.*/##")

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       id: extract_repo
       run: |
         REPO_NAME=$(echo ${{ github.repository }} | sed -e "s#.*/##")
-        echo "REPOSITORY=$REPO_NAME" >> $GITHUB_ENV
+        echo "REPO_NAME=$REPO_NAME" >> $GITHUB_ENV
 
     - name: Set up Node.js
       uses: actions/setup-node@v3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,33 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build and Export
+      run: |
+        npm run build
+        npm run export
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./out

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+     - name:  Set repository name
+      id: extract_repo
+      run: |
+        REPO_NAME=$(echo ${{ github.repository }} | sed -e "s#.*/##")
+        echo "REPOSITORY=$REPO_NAME" >> $GITHUB_ENV
+
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
@@ -22,6 +28,8 @@ jobs:
       run: npm ci
 
     - name: Build and Export
+      env:
+        REPO_NAME: ${{ env.REPO_NAME }}
       run: |
         npm run build
         npm run export

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,7 @@ const repoName = process.env.REPO_NAME || "";
 const nextConfig = {
   basePath: `/${repoName}`,
   assetPrefix: `/${repoName}/`,
+  output: 'export',
 }
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {}
+const repoName = process.env.REPO_NAME || "";
 
-module.exports = nextConfig
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  basePath: `/${repoName}`,
+  assetPrefix: `/${repoName}/`,
+}
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "export": "next export"
   },
   "dependencies": {
     "@types/node": "20.3.3",


### PR DESCRIPTION
GitHub Pages として公開するブランチを gh-pages にするだけで公開できます。
main に Push すると勝手にビルドとブランチにデプロイをする GitHub Actions が走ります。

動的レンダリングが必要になったら消しましょう。
